### PR TITLE
Fix half carry flag logic in alu_add_hl

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -275,7 +275,7 @@ impl Cpu {
         let a = self.reg.get_hl();
         let r = a.wrapping_add(n);
         self.reg.set_flag(C, a > 0xffff - n);
-        self.reg.set_flag(H, (a & 0x07ff) + (n & 0x07ff) > 0x07ff);
+        self.reg.set_flag(H, (a & 0x0fff) + (n & 0x0fff) > 0x0fff);
         self.reg.set_flag(N, false);
         self.reg.set_hl(r);
     }


### PR DESCRIPTION
Correct me if I'm wrong, but I think a mask of 0x0FFF is consistent with the 8-bit alu_add function:

```rust        
self.reg.set_flag(C, u16::from(a) + u16::from(n) > 0xff);
self.reg.set_flag(H, (a & 0x0f) + (n & 0x0f) > 0x0f);
```

and other emulators I've checked with: [SameBoy][sb], [binjgb][bg], [CoffeeGB][cg]

[sb]: https://github.com/LIJI32/SameBoy/blob/9f7255cd239c55af4356d76e22e1c57d20c164ba/Core/sm83_cpu.c#L373-L376
[bg]: https://github.com/binji/binjgb/blob/8b48580f3266e7cebac7c36e97d30d801e997d0c/src/emulator.c#L3559
[cg]: https://github.com/trekawek/coffee-gb/blob/088b86fb17109b8cac98e6394108b3561f443d54/src/main/java/eu/rekawek/coffeegb/cpu/AluFunctions.java#L49