### PR TITLE
make command line options more discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ You can start a game with the following command, here with a built-in game "Boxe
 $ cargo run -- "./res/boxes.gb"
 ```
 
+You can run a game with audio with the command
+
+```s
+$ cargo run -- -a "./res/boxes.gb"
+```
+
+You can run the game scaled up to a larger size with
+
+```s
+$ cargo run -- -x 4 "./res/boxes.gb"
+```
+
 Gameboy is developed by Rust, and fully tested on Windows, Ubuntu and Mac.
 
 # Control

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -428,7 +428,7 @@ impl Cpu {
     // C - Contains old bit 0 data
     fn alu_rrc(&mut self, a: u8) -> u8 {
         let c = a & 0x01 == 0x01;
-        let r = if c { 0x80 | (a >> 1) } else { (a >> 1) };
+        let r = if c { 0x80 | (a >> 1) } else { a >> 1 };
         self.reg.set_flag(C, c);
         self.reg.set_flag(H, false);
         self.reg.set_flag(N, false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,13 @@ fn main() {
         let mut ap = argparse::ArgumentParser::new();
         ap.set_description("Gameboy emulator");
         ap.refer(&mut c_audio)
-            .add_option(&["-a"], argparse::StoreTrue, "Enable audio");
+            .add_option(&["-a", "--enable-audio"],
+                        argparse::StoreTrue,
+                        "Enable audio");
         ap.refer(&mut c_scale)
-            .add_option(&["-x"], argparse::Store, "Scale the video");
+            .add_option(&["-x", "--scale-factor"],
+                        argparse::Store,
+                        "Scale the video by a factor of 1, 2, 4, or 8");
         ap.refer(&mut rom).add_argument("rom", argparse::Store, "Rom name");
         ap.parse_args_or_exit();
     }


### PR DESCRIPTION
First, this is an awesome project! I looked into a couple of other
gameboy emulators with many more commits and contributors
before trying out this one, and this was the first project that worked.

I'm fortunate enough to be able to figure out the command line flags
by reading sources, but I suspect that not everyone who is interested
in using this project will have that option open to them so I thought
I would send you a patch to try to make the command line flags a little
more discoverable.

Adding the long-form flags gives argparse something to use as the argument
name in its help message. The new usage message is:

```
Usage:
  target/debug/gameboy [OPTIONS] [ROM]

Gameboy emulator

Positional arguments:
  rom                   Rom name

Optional arguments:
  -h,--help             Show this help message and exit
  -a,--enable-audio     Enable audio
  -x,--scale-factor SCALE_FACTOR
                        Scale the video by a factor of 1, 2, 4, or 8
```

I also fixed a compiler warning.