### PR TITLE
WIP ssh container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+ARG BASE_IMAGE=frolvlad/alpine-rust
+FROM $BASE_IMAGE as builder
+
+COPY res res
+COPY src src
+COPY examples examples
+ADD Cargo.toml .
+ADD Cargo.lock .
+
+RUN cargo build --release --no-default-features --features tty
+
+EXPOSE 2222
+
+run cp target/release/gameboy /usr/bin/
+RUN apk add --no-cache openssh \
+  && sed -i s/#PermitRootLogin.*/PermitRootLogin\ yes/ /etc/ssh/sshd_config \
+  && echo "root:root" | chpasswd
+run echo "ForceCommand /usr/bin/http-gameboy.sh" >> /etc/ssh/sshd_config
+run ssh-keygen -A
+COPY http-gameboy.sh /usr/bin/
+ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e", "-p", "2222"]
+

--- a/http-gameboy.sh
+++ b/http-gameboy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -xe
+echo please enter a zip url for your rom
+read url
+wget "$url" -O "rom.zip"
+unzip rom.zip
+gameboy *.gb*


### PR DESCRIPTION
I dont know if this is the right repo for this, please tell me if it is not.

Adds a dockerfile to host the emulator in tty mode as an SSH container.
On ssh connection:
1. prompts for a zip HTTP url from which to download the rom
2. downloads the rom and unzip it
3. starts the emulator with the rom